### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/XML/Signature.pm6
+++ b/lib/XML/Signature.pm6
@@ -6,7 +6,7 @@ use Digest::SHA;
 use MIME::Base64;
 use UUID;
 
-module XML::Signature;
+unit module XML::Signature;
 
 our sub sign(XML::Element $document is rw, :$private-pem!, :$x509-pem! is copy, :$enveloping, :$enveloped, :$detached) is export {
     $x509-pem ~~ s:g/\s+//;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
